### PR TITLE
fix: MEECROWAVE-323 - incorrect filename

### DIFF
--- a/meecrowave-core/pom.xml
+++ b/meecrowave-core/pom.xml
@@ -617,6 +617,9 @@
                 <relocation>
                   <pattern>javax.annotation</pattern>
                   <shadedPattern>jakarta.annotation</shadedPattern>
+                  <excludes>
+                    <exclude>javax.annotation.processing.**</exclude>
+                  </excludes>
                 </relocation>
                 <relocation>
                   <pattern>javax.el</pattern>


### PR DESCRIPTION
Bug with erroneous automatic renaming file solved - [MEECROWAVE-323](https://issues.apache.org/jira/browse/MEECROWAVE-323).

I have used the solution [from johnzon](https://github.com/apache/johnzon/blob/master/pom.xml#L131) :)

Signed-off-by: Vladimir V. Bychkov <github@bychkov.name>